### PR TITLE
Make scan package in zip work on py26

### DIFF
--- a/venusian/__init__.py
+++ b/venusian/__init__.py
@@ -198,10 +198,13 @@ class Scanner(object):
                         else: # pragma: no cover
                             # py3.3b2+ (importlib-using)
                             module_type = imp.PY_SOURCE
+                            get_filename = getattr(loader, 'get_filename', None)
+                            if get_filename is None:
+                                get_filename = loader._get_filename
                             try:
-                                fn = loader.get_filename(modname)
+                                fn = get_filename(modname)
                             except TypeError:
-                                fn = loader.get_filename()
+                                fn = get_filename()
                             if fn.endswith(('.pyc', '.pyo', '$py.class')):
                                 module_type = imp.PY_COMPILED
                         # only scrape members from non-orphaned source files


### PR DESCRIPTION
py26 has no `loader.get_filename` but it has `loader._get_filename`.